### PR TITLE
V1: made socket dial in functions cancellable

### DIFF
--- a/api/smp.go
+++ b/api/smp.go
@@ -1,6 +1,7 @@
 package smp
 
 import (
+	"context"
 	"time"
 
 	"github.com/netsys-lab/scion-path-discovery/packets"
@@ -475,4 +476,12 @@ func (l *MPListener) Listen() error {
 // That dials back to the incoming socket
 func (l *MPListener) WaitForMPPeerSockConnect() (*snet.UDPAddr, error) {
 	return l.socket.WaitForDialIn()
+}
+
+// Waits for new incoming MPPeerSocks
+// Should be called in a loop
+// Using the returned addr, a new MPPeerSock can be instantiated
+// That dials back to the incoming socket
+func (l *MPListener) WaitForMPPeerSockConnectWithContext(ctx context.Context) (*snet.UDPAddr, error) {
+	return l.socket.WaitForDialInWithContext(ctx)
 }

--- a/packets/quicconn.go
+++ b/packets/quicconn.go
@@ -244,6 +244,24 @@ func (qc *QUICReliableConn) AcceptStream() (quic.Stream, error) {
 	return stream, nil
 }
 
+func (qc *QUICReliableConn) AcceptStreamWithContext(ctx context.Context) (quic.Stream, error) {
+	log.Debugf("Accepting on quic %s", qc.listener.Addr())
+	session, err := qc.listener.Accept(ctx)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Got session on quic %s", qc.listener.Addr())
+
+	stream, err := session.AcceptStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// qc.internalConn = stream
+
+	return stream, nil
+}
+
 func (qc *QUICReliableConn) Listen(addr snet.UDPAddr) error {
 	qc.Ready = make(chan bool, 0)
 	udpAddr := net.UDPAddr{

--- a/socket/scionsocket.go
+++ b/socket/scionsocket.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"os"
+	"time"
 
 	"github.com/netsys-lab/scion-path-discovery/packets"
 	"github.com/netsys-lab/scion-path-discovery/pathselection"
@@ -76,8 +78,31 @@ func (s *SCIONSocket) WaitForDialIn() (*snet.UDPAddr, error) {
 }
 
 func (s *SCIONSocket) WaitForDialInWithContext(ctx context.Context) (*snet.UDPAddr, error) {
-	//TODO implement context support for SCION socket
-	panic("implement SCIONSocket.WaitForDialInWithContext(context.Context)")
+	for {
+		deadline, hasDeadline := ctx.Deadline()
+		var err error
+		if hasDeadline {
+			err = s.connections[0].SetReadDeadline(deadline)
+		} else {
+			err = s.connections[0].SetDeadline(time.Now().Add(5 * time.Second))
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		addr, err := s.WaitForDialIn()
+		if err == nil {
+			return addr, nil
+		} else if !os.IsTimeout(err) {
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
 }
 
 func (s *SCIONSocket) Dial(remote snet.UDPAddr, path snet.Path, options DialOptions, i int) (packets.UDPConn, error) {

--- a/socket/scionsocket.go
+++ b/socket/scionsocket.go
@@ -2,6 +2,7 @@ package socket
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
 
 	"github.com/netsys-lab/scion-path-discovery/packets"
@@ -72,6 +73,11 @@ func (s *SCIONSocket) WaitForDialIn() (*snet.UDPAddr, error) {
 	addr := p.Addr
 
 	return &addr, nil
+}
+
+func (s *SCIONSocket) WaitForDialInWithContext(ctx context.Context) (*snet.UDPAddr, error) {
+	//TODO implement context support for SCION socket
+	panic("implement SCIONSocket.WaitForDialInWithContext(context.Context)")
 }
 
 func (s *SCIONSocket) Dial(remote snet.UDPAddr, path snet.Path, options DialOptions, i int) (packets.UDPConn, error) {

--- a/socket/scionsocket_test.go
+++ b/socket/scionsocket_test.go
@@ -1,7 +1,10 @@
 package socket
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	lookup "github.com/netsys-lab/scion-path-discovery/pathlookup"
 	"github.com/netsys-lab/scion-path-discovery/pathselection"
@@ -62,6 +65,24 @@ func Test_SCIONSocket(t *testing.T) {
 		}
 		sock.CloseAll()
 		sock2.CloseAll()
+	})
+
+	t.Run("SCIONSocket Listen And Contextualized Wait For Dial", func(t *testing.T) {
+		sock := NewSCIONSocket("1-ff00:0:110,[127.0.0.12]:21000")
+		err := sock.Listen()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer sock.CloseAll()
+
+		ctx, cancelFunc := context.WithDeadline(context.Background(), time.Now())
+		defer cancelFunc()
+		_, err = sock.WaitForDialInWithContext(ctx)
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			t.Error(err)
+			return
+		}
 	})
 
 }

--- a/socket/socket.go
+++ b/socket/socket.go
@@ -1,6 +1,7 @@
 package socket
 
 import (
+	"context"
 	"github.com/netsys-lab/scion-path-discovery/packets"
 	"github.com/netsys-lab/scion-path-discovery/pathselection"
 	"github.com/scionproto/scion/go/lib/snet"
@@ -26,6 +27,7 @@ type DialOptions struct {
 type UnderlaySocket interface {
 	Listen() error
 	WaitForDialIn() (*snet.UDPAddr, error)
+	WaitForDialInWithContext(ctx context.Context) (*snet.UDPAddr, error)
 	WaitForIncomingConn() (packets.UDPConn, error)
 	Dial(remote snet.UDPAddr, path snet.Path, options DialOptions, i int) (packets.UDPConn, error)
 	DialAll(remote snet.UDPAddr, path []pathselection.PathQuality, options DialOptions) ([]packets.UDPConn, error)


### PR DESCRIPTION
This pull request is a feature addition for version 1. It should be rewritten for version 2 so it does not branch in terms of functionality.

It adds `socket.WaitForDialInWithContext` and `conn.AcceptStreamWithContext` functions to the socket implementations that accept a cancellable context so that they can be stopped from blocking indefinitely without killing the whole application.