### PR TITLE
V1: made waiting for peer connections cancellable

### DIFF
--- a/socket/scionsocket.go
+++ b/socket/scionsocket.go
@@ -140,6 +140,10 @@ func (s *SCIONSocket) WaitForIncomingConn() (packets.UDPConn, error) {
 	return nil, nil
 }
 
+func (s *SCIONSocket) WaitForIncomingConnWithContext(ctx context.Context) (packets.UDPConn, error) {
+	return nil, nil
+}
+
 func (s *SCIONSocket) DialAll(remote snet.UDPAddr, path []pathselection.PathQuality, options DialOptions) ([]packets.UDPConn, error) {
 	// There is always one listening connection
 	conns := make([]packets.UDPConn, 1)

--- a/socket/socket.go
+++ b/socket/socket.go
@@ -29,6 +29,7 @@ type UnderlaySocket interface {
 	WaitForDialIn() (*snet.UDPAddr, error)
 	WaitForDialInWithContext(ctx context.Context) (*snet.UDPAddr, error)
 	WaitForIncomingConn() (packets.UDPConn, error)
+	WaitForIncomingConnWithContext(ctx context.Context) (packets.UDPConn, error)
 	Dial(remote snet.UDPAddr, path snet.Path, options DialOptions, i int) (packets.UDPConn, error)
 	DialAll(remote snet.UDPAddr, path []pathselection.PathQuality, options DialOptions) ([]packets.UDPConn, error)
 	CloseAll() []error


### PR DESCRIPTION
This pull request is a feature addition for version 1. It should be rewritten for version 2 so it does not branch in terms of functionality.

It adds the `smp.WaitForPeerConnectWithContext` function that, in addition to the exact features of `smp.WaitForPeerConnect`, accepts a cancellable context so that it can be stopped from blocking indefinitely without killing the whole application. In the process, `socket.WaitForIncomingConnWithContext` was introduced as well.